### PR TITLE
feat: Allow GetObjectAcl on S3 to s3-access-role

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In the above diagram, you can see the components and their relations (PostgreSQL
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.11.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.33.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.35.1 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In the above diagram, you can see the components and their relations (PostgreSQL
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.11.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.35.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.33.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -139,6 +139,17 @@ data "aws_iam_policy_document" "s3_bucket_policy" {
     actions   = ["s3:DeleteObject"]
     resources = ["arn:aws:s3:::${each.value}/*"]
   }
+
+  statement {
+    sid    = "AllowGetObjectAclForGitlabRole"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [module.gitlab_role.iam_role_arn]
+    }
+    actions   = ["s3:GetObjectAcl"]
+    resources = ["arn:aws:s3:::${each.value}/*"]
+  }
 }
 
 module "s3_bucket" {

--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,17 @@ data "aws_iam_policy_document" "s3_bucket_policy" {
   }
 
   statement {
+    sid    = "AllowPutObjectAclForGitlabRole"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [module.gitlab_role.iam_role_arn]
+    }
+    actions   = ["s3:PutObjectAcl"]
+    resources = ["arn:aws:s3:::${each.value}/*"]
+  }
+
+  statement {
     sid    = "AllowGetObjectAclForGitlabRole"
     effect = "Allow"
     principals {


### PR DESCRIPTION
Restore testing of deployment fails due to lack of permissions